### PR TITLE
Update Vault image version to 1.21

### DIFF
--- a/bin/Vault/compose.yml
+++ b/bin/Vault/compose.yml
@@ -23,7 +23,7 @@ version: '3.8'
  
 services:
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.21
     restart: unless-stopped
     container_name: mydigifarm-vault
     ports:


### PR DESCRIPTION
Completes mydigifarm/alphaprototype#7
Failed to update vault versioning. 